### PR TITLE
Feature: Performance Optomization

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -175,6 +175,7 @@ export default class Client {
           } else return bValue.priority - aValue.priority;
         })
       );
+      this.hasUnsortedRequests = false;
     }
     return this.pendingRequests.entries().next().value;
   }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -18,7 +18,6 @@ export type RateLimitChange = (
 export interface ClientConstructorData {
   client: CreateClientData;
   redis: IORedis;
-  redisListener: IORedis;
   requestHandlerRedisName: string;
   logger: Logger;
   key: string;
@@ -88,5 +87,6 @@ export interface RequestMetadata {
   priority: number;
   timestamp: number;
   requestId: string;
+  clientId: string;
   cost: number;
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -89,4 +89,5 @@ export interface RequestMetadata {
   requestId: string;
   clientId: string;
   cost: number;
+  retries: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,6 @@ export default class RequestHandler {
     const client = new Client({
       client: data,
       redis: this.redis,
-      redisListener: this.redisListener,
       requestHandlerRedisName: this.redisName,
       logger: this.logger,
       key: this.key,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export default class RequestHandler {
     this.redisName = `${
       data.redisKeyPrefix ? `${data.redisKeyPrefix}:` : ""
     }requestHandler`;
-    this.redisListener = data.redis.duplicate().setMaxListeners(0);
+    this.redisListener = data.redis.duplicate().setMaxListeners(3);
     this.key = data.key;
     this.clientGenerators = data.clientGenerators || {};
     this.defaultClient = data.defaultClientOptions || {
@@ -308,9 +308,11 @@ export default class RequestHandler {
    */
 
   private async startRedis() {
-    await this.redisListener.subscribe(`${this.redisName}:regenerateClients`);
-    await this.redisListener.subscribe(`${this.redisName}:destroyClient`);
-    await this.redisListener.subscribe(`${this.redisName}:nodeUpdate`);
+    await this.redisListener.subscribe(
+      `${this.redisName}:regenerateClients`,
+      `${this.redisName}:destroyClient`,
+      `${this.redisName}:nodeUpdate`
+    );
     this.redisListener.on("message", this.handleRedisMessage.bind(this));
   }
 


### PR DESCRIPTION
## Description

This PR increases the performance of request handler by doing the following:

- Switch `processingIds`, which was an array, to `processingId`, which is a simple string
  - Reduces the processing needed every `processRequests` iteration to see if there are multiple processors running
- Switch `pendingRequests` from an array to a Map and only sort if the new `hasUnsortedRequests` flag is set
  - Previously, requests were sorted every iteration of `processRequests`, which was unnecessary. Now, anytime a new request is added, the `hadUnsortedRequests` flag is set, which tells `processRequests` whether to sort the requests before it returns the next one
  - By using a Map, there are no longer more expensive array methods for removing requests from the `pendingRequests` array
- Remove unnecessary Redis subscriptions
  - Previously, both `slave` and `master` nodes were subscribed to all channels, even if there was no reason for the `slave` to be listening.
- Node level `redisListener`
  - Previously, all `Client` classes shared the same `redisListener`, which meant all `Client` classes were processing every message from all the other `Client` classes
- Rate Limiting Thaw
  - Previously, whenever there was a request freeze, once over, the `Client` would requests to go at full speed.
  - Now with the thaw functionality, the `Client` will send requests one at a time until 3 requests come back with successful responses before it allows the normal full speed