### PR TITLE
Bugfix: Re-publicize methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vivo-technology/request-handler",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An external API management tool that simplifies authentication and usage of external APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export default class RequestHandler {
    * @param generatorNames Optional names of generators to regenerate clients for
    */
 
-  protected async regenerateClients(generatorNames?: string[]) {
+  public async regenerateClients(generatorNames?: string[]) {
     await this.redis.publish(
       `${this.redisName}:regenerateClients`,
       JSON.stringify(generatorNames || [])
@@ -140,7 +140,7 @@ export default class RequestHandler {
    * @param clientName The name of the client to destroy
    */
 
-  protected async destroyClient(clientName: string) {
+  public async destroyClient(clientName: string) {
     this.getClient(clientName);
     await this.redis.publish(
       `${this.redisName}:destroyClient`,


### PR DESCRIPTION
## Description

This PR re-publicizes the `destroyClient` and `regenerateClients` methods that were public before `v0.4.0`