### PR TITLE
Bugfix: Handle Request Response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vivo-technology/request-handler",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "An external API management tool that simplifies authentication and usage of external APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/handleRequest.ts
+++ b/src/client/handleRequest.ts
@@ -1,5 +1,6 @@
+import handleRequestResponse from "./handleRequestResponse";
+import handleRequestError from "./handleRequestError";
 import { RequestConfig } from "../request/types";
-import handleResponse from "./handleResponse";
 import { AxiosResponse } from "axios";
 import BaseError from "../baseError";
 import Request from "../request";
@@ -13,10 +14,10 @@ async function handleRequest(this: Client, config: RequestConfig) {
     try {
       res = await this.http.request(request.config);
     } catch (error: any) {
-      await handleResponse.bind(this)(request, error);
+      await handleRequestError.bind(this)(request, error);
       continue;
     }
-    await handleResponse.bind(this)(request, res);
+    await handleRequestResponse.bind(this)(request, res);
   } while (!res && request.retries <= request.maxRetries);
   return await handlePostResponse.bind(this)(request, res);
 }

--- a/src/client/handleRequestResponse.ts
+++ b/src/client/handleRequestResponse.ts
@@ -1,0 +1,29 @@
+import { RequestDoneData } from "./types";
+import { AxiosResponse } from "axios";
+import Request from "../request";
+import Client from ".";
+
+async function handleResponse(
+  this: Client,
+  request: Request,
+  res: AxiosResponse
+) {
+  const data: RequestDoneData = {
+    cost: request.config.cost || 1,
+    status: "success",
+    requestId: request.id,
+    waitTime: 0,
+    isRateLimited: false,
+  };
+  await this.redis.publish(
+    `${this.redisName}:requestDone`,
+    JSON.stringify(data)
+  );
+  if (this.rateLimitChange) {
+    const newLimit = await this.rateLimitChange(this.rateLimit, res);
+    if (newLimit) await this.updateRateLimit(newLimit);
+  }
+  return res;
+}
+
+export default handleResponse;


### PR DESCRIPTION
## Description

This PR fixes an issue where the `handleResponse` function would throw a `BaseError` rather than the `AxiosError` from the request. This meant that the user would not see what the actual error was. To simplify troubleshooting the request response in the future, the `handleResponse` function was broken up into `handleRequestResponse` and `handleRequestError`.