### PR TITLE
Fix: Move some types from Request to Client level

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ All normal Axios [Request Config](https://axios-http.com/docs/req_config) option
 - `rateLimitChange` *(optional)*: A function that is called after each response is received to allow a check of whether the rate limit should be changed.
 - `sharedRateLimitClientName` *(optional)*: The name of another client to share rate limits with.
 - `requestOptions` *(optional)*: A set of options to pass to each request made by the client. This is useful if there are common parameters that need to be passed to each request. See the [Request Options](#request-options) section for more information.
+- `httpStatusCodesToMute` *(optional)*: A list of HTTP status codes to not log as errors. By default, all 4xx and 5xx status codes are logged as errors.
+- `retryOptions` *(optional)*: An object that contains options for retrying requests.
+  - `maxRetries` *(optional)*: The maximum number of times to retry a request if it fails. Defaults to 3.
+  - `retryBackoffBaseTime` *(optional)*: The base time in milliseconds that the retry backoff will calculate from. Defaults to 1000.
+  - `retryBackoffMethod` *(optional)*: The method to use for calculating how much time to wait between retry attempts. Options are `exponential` and `linear`. Defaults to `exponential`.
+  - `retry429s` *(optional)*: Whether or not to retry 429 errors. Defaults to `true`.
+  - `retry5xxs` *(optional)*: Whether or not to retry 5xx errors. Defaults to `true`.
+  - `retryHandler` *(optional)*: A function that allows you to use custom logic to determine whether a request should be retried.
+  - `retryStatusCodes` *(optional)*: An explicit list of HTTP status codes to retry
+  - `thawRequestCount` *(optional)*: The number of requests in a row that must come back with a 2xx status to start sending requests at full speed again after a rate limit has been breached. Defaults to `3`.
 - `metadata` *(optional)*: Any metadata you want to store with the client.
 - `axiosOptions` *(optional)*: Any Axios [Request Config](https://axios-http.com/docs/req_config) options you want to pass to the axios instance for this client.
 - `authentication` *(optional)*: An object to define how to authenticate requests. There are currently 4 types of authentication supported: `oauth2ClientCredentials`, `oauth2GrantType`, `token`, and `basic`. See the [Authentication Options](#authentication-options) section for more information.
@@ -237,20 +247,10 @@ const clientGenerator = () => {
 
 - `cleanupTimeout` *(optional)*: The number of milliseconds to wait before counting a request as timed out and to clean up the request.
 - `metadata` *(optional)*: A general object that can be used to store any metadata you want to pass to the request.
-- `retryOptions` *(optional)*: An object that contains options for retrying requests.
-  - `maxRetries` *(optional)*: The maximum number of times to retry a request if it fails. Defaults to 3.
-  - `retryBackoffBaseTime` *(optional)*: The base time in milliseconds that the retry backoff will calculate from. Defaults to 1000.
-  - `retryBackoffMethod` *(optional)*: The method to use for calculating how much time to wait between retry attempts. Options are `exponential` and `linear`. Defaults to `exponential`.
-  - `retry429s` *(optional)*: Whether or not to retry 429 errors. Defaults to `true`.
-  - `retry5xxs` *(optional)*: Whether or not to retry 5xx errors. Defaults to `true`.
-  - `retryHandler` *(optional)*: A function that allows you to use custom logic to determine whether a request should be retried.
-  - `retryStatusCodes` *(optional)*: An explicit list of HTTP status codes to retry
-  - `thawRequestCount` *(optional)*: The number of requests in a row that must come back with a 2xx status to start sending requests at full speed again after a rate limit has been breached. Defaults to `3`.
 - `defaults` *(optional)*: A set of optional default values to pass to each request made by the client.
   - `headers` *(optional)*: A set of headers to pass to each request made by the client.
   - `baseURL` *(optional)*: The base URL to use for each request made by the client.
   - `params` *(optional)*: A set of query parameters to pass to each request made by the client.
-- `httpStatusCodesToMute` *(optional)*: A list of HTTP status codes to not log as errors. By default, all 4xx and 5xx status codes are logged as errors.
 - `requestInterceptor` *(optional)*: A function that allows requests to be manipulated before they are sent. This is useful for authentcating, adding headers or other information to requests.
 - `responseInterceptor` *(optional)*: A function that allows responses to be read in a consistent way. This is useful for reading data from the response, such as rate limit information, or for logging the responses.
 

--- a/src/client/handleRequest.ts
+++ b/src/client/handleRequest.ts
@@ -23,8 +23,7 @@ async function handleRequest(this: Client, config: RequestConfig) {
 }
 
 async function generateRequest(this: Client, config: RequestConfig) {
-  const maxRetries = this.requestOptions?.retryOptions?.maxRetries || 3;
-  const request = new Request(config, maxRetries);
+  const request = new Request(config, this.retryOptions.maxRetries);
   handleRequestDefaults.bind(this)(request);
   const { method, baseURL, url } = request.config;
   this.logger.debug(

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -44,6 +44,10 @@ export interface CreateClientData {
   sharedRateLimitClientName?: string;
   /** Options to pass to each request */
   requestOptions?: RequestOptions;
+  /** Options to configure the retry behavior of the request handler. */
+  retryOptions?: Partial<RetryOptions>;
+  /** Any HTTP status code included in this array will result in a debug log rather than an error log */
+  httpStatusCodesToMute?: number[];
   /** Optional object for storing other data with the updater */
   metadata?: { [key: string]: any };
   /**
@@ -109,15 +113,9 @@ export interface RequestOptions {
   /** Metadata to carry with the request. It is up to the user to validate the metadata */
   metadata?: Record<string, any>;
   /**
-   * Options to configure the retry behavior of the request handler.
-   */
-  retryOptions?: Partial<RetryOptions>;
-  /**
    * Default values to set for each request
    */
   defaults?: RequestDefaults;
-  /** Any HTTP status code included in this array will result in a debug log rather than an error log */
-  httpStatusCodesToMute?: number[];
   /**
    * Allows the user to intercept the request before it is sent and manipulate it.
    *
@@ -184,13 +182,13 @@ export interface RetryOptions {
    */
   retryHandler?: RetryHandler;
   /** An array of status codes to retry on */
-  retryStatusCodes?: number[];
+  retryStatusCodes: number[];
   /**
    * The number of requests in a row must come back with a 2xx status to start sending requests at full speed again after a rate limit has been breached
    *
    * **Default value: 3**
    */
-  thawRequestCount?: number;
+  thawRequestCount: number;
 }
 
 export interface RequestDefaults {

--- a/src/initNode/createClients.ts
+++ b/src/initNode/createClients.ts
@@ -87,10 +87,10 @@ function mergeChildParentClients(
         ...parent.requestOptions?.defaults,
         ...child.requestOptions?.defaults,
       },
-      retryOptions: {
-        ...parent.requestOptions?.retryOptions,
-        ...child.requestOptions?.retryOptions,
-      },
+    },
+    retryOptions: {
+      ...parent.retryOptions,
+      ...child.retryOptions,
     },
   };
   return merged;


### PR DESCRIPTION
## Description

This PR moves the following types from the request level to the client level as this is more accurate to how they are being used/access.

- `retryOptions`
- `httpStatusCodesToMute`