### PR TITLE
Bugfix: Concurrency Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Concurrency limitted clients allow you to limit the number of concurrent request
 
 Additional properties:
 
-- `maxConcurrent`: The maximum number of concurrent requests to allow.
+- `maxTokens`: The maximum number of concurrent requests to allow.
 
 ```js
 const clientGenerator = () => {
@@ -220,7 +220,7 @@ const clientGenerator = () => {
         name: "test",
         rateLimit: {
           type: "concurrencyLimit",
-          maxConcurrency: 10
+          maxTokens: 10
         }
       }
     ]


### PR DESCRIPTION
## Description

This PR fixes an issue where concurrency limited clients still used the `maxConcurrency` rather than `maxTokens` wording in the `readme.md` file