### PR TITLE
Bugfix: Init Node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ export default class RequestHandler {
   protected redisName: string;
   protected redisListener: IORedis;
   protected logger: Logger;
-  protected requestHandlers: Map<string, RequestHandlerMetadata> = new Map();
   protected nodeHeartbeatTimeouts: Map<string, NodeJS.Timeout> = new Map();
   protected nodeHeartbeatInterval?: NodeJS.Timeout;
   protected emitter: NodeJS.EventEmitter = new EventEmitter();

--- a/src/initNode/index.ts
+++ b/src/initNode/index.ts
@@ -1,11 +1,7 @@
+import updateClientRoles from "./updateClientRoles";
 import createClients from "./createClients";
 import startRedis from "./startRedis";
 import RequestHandler from "..";
-import {
-  updateClientRoles,
-  updateNodeRegistration,
-  updateNodesMap,
-} from "./helpers";
 
 /**
  * Initializes the request handler by:
@@ -16,14 +12,7 @@ async function initNode(this: RequestHandler) {
   if (this.isInitialized) return;
   await startRedis.bind(this)();
   await createClients.bind(this)();
-  await updateNodesMap.bind(this)();
-  await updateNodeRegistration.bind(this)(false);
-  await this.redis.sadd(`${this.redisName}:nodes`, this.id);
-  await updateClientRoles.bind(this)(false);
-  await this.redis.publish(
-    `${this.redisName}:nodeAdded`,
-    JSON.stringify(this.getMetadata())
-  );
+  await updateClientRoles.bind(this)();
   this.isInitialized = true;
   this.emitter.emit("nodeInitialized");
   this.logger.info(`Initialized request handler node with ID ${this.id}`);


### PR DESCRIPTION
## Description

This PR fixes an issue where a new Request Handler node or cluster would not properly negotiate which clients are the controllers. To resolve this, the `initNode` function has been refactored to be more simple and all nodes check Redis for the latest nodes status when its updates its client roles