### PR TITLE
Bugfix: Client Stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vivo-technology/request-handler",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "An external API management tool that simplifies authentication and usage of external APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -322,12 +322,22 @@ export default class Client {
   }
 
   public getStats(): ClientTypes.ClientStatistics {
+    let rateLimit: ClientTypes.CreatedRateLimit;
+    if (this.rateLimit.type === "requestLimit") {
+      rateLimit = {
+        type: "requestLimit",
+        tokens: this.rateLimit.tokens,
+        maxTokens: this.rateLimit.maxTokens,
+        interval: this.rateLimit.interval,
+        tokensToAdd: this.rateLimit.tokensToAdd,
+      };
+    } else rateLimit = this.rateLimit;
     const stats: ClientTypes.ClientStatistics = {
       clientName: this.name,
       isFrozen: this.freezeTimeout !== undefined,
       isThawing: this.thawRequestId !== undefined,
       thawRequestCount: this.thawRequestCount,
-      rateLimit: this.rateLimit,
+      rateLimit,
       requestsInQueue: { count: 0, cost: 0, requests: [] },
       requestsInProgress: { count: 0, cost: 0, requests: [] },
     };


### PR DESCRIPTION
## Description

This PR fixes an issue where the `getStats` function would return the `addTokensInterval`, which could cause issues with any `JSON.stringify()` calls and was not useful data to begin with.