### PR TITLE
Bugfix: Wait for Tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vivo-technology/request-handler",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "An external API management tool that simplifies authentication and usage of external APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/processRequests.ts
+++ b/src/client/processRequests.ts
@@ -80,7 +80,10 @@ function waitForTurn(this: Client, cost: number): Promise<boolean> {
 
 function waitForTokens(this: Client, cost: number): Promise<boolean> {
   if (this.rateLimit.type !== "requestLimit") return Promise.resolve(true);
-  if (this.rateLimit.tokens >= cost) return Promise.resolve(true);
+  if (this.rateLimit.tokens >= cost) {
+    this.rateLimit.tokens -= cost;
+    return Promise.resolve(true);
+  }
   return new Promise((resolve) => {
     const listener = async () => {
       if (this.rateLimit.type !== "requestLimit") return;


### PR DESCRIPTION
## Description

This PR fixes an issue where if there were enough tokens, `requestLimit` requests would be sent without removing a token