### PR TITLE
Fix: Make handleTokensUpdated not abstract

### DIFF
--- a/src/client/clientTypes/concurrencyLimitClient.ts
+++ b/src/client/clientTypes/concurrencyLimitClient.ts
@@ -2,7 +2,6 @@ import { RequestDoneData } from "../../request/types";
 import BaseClient from "..";
 import {
   ClientConstructorData,
-  ClientTokensUpdatedData,
   ConcurrencyLimitClientOptions,
   RateLimitStats,
   RateLimitUpdatedData,
@@ -16,10 +15,6 @@ class ConcurrencyLimitClient extends BaseClient {
   ) {
     super(data, data.client.name);
     this.rateLimit = rateLimit;
-  }
-
-  public handleTokensUpdated(data: ClientTokensUpdatedData): void {
-    return;
   }
 
   public handleRateLimitUpdated(data: RateLimitUpdatedData) {

--- a/src/client/clientTypes/noLimitClient.ts
+++ b/src/client/clientTypes/noLimitClient.ts
@@ -3,7 +3,6 @@ import BaseClient from "..";
 import {
   ClientConstructorData,
   ClientRole,
-  ClientTokensUpdatedData,
   NoLimitClientOptions,
   RateLimitStats,
   RateLimitUpdatedData,
@@ -14,10 +13,6 @@ class NoLimitClient extends BaseClient {
   constructor(data: ClientConstructorData, rateLimit: NoLimitClientOptions) {
     super(data, data.client.name);
     this.rateLimit = rateLimit;
-  }
-
-  public handleTokensUpdated(data: ClientTokensUpdatedData): void {
-    return;
   }
 
   public handleRateLimitUpdated(data: RateLimitUpdatedData) {

--- a/src/client/clientTypes/requestLimitClient.ts
+++ b/src/client/clientTypes/requestLimitClient.ts
@@ -30,9 +30,9 @@ class RequestLimitClient extends BaseClient {
   public handleRateLimitUpdated(data: RateLimitUpdatedData) {
     if (data.rateLimit.type !== "requestLimit") return;
     this.rateLimit = data.rateLimit;
-    this.tokens > data.rateLimit.maxTokens
-      ? data.rateLimit.maxTokens
-      : this.tokens;
+    if (this.tokens > data.rateLimit.maxTokens) {
+      this.tokens = data.rateLimit.maxTokens;
+    }
     this.startAddTokensInterval();
   }
 

--- a/src/client/clientTypes/sharedLimitClient.ts
+++ b/src/client/clientTypes/sharedLimitClient.ts
@@ -3,7 +3,6 @@ import BaseClient from "..";
 import {
   ClientConstructorData,
   ClientRole,
-  ClientTokensUpdatedData,
   SharedLimitClientOptions,
   RateLimitStats,
   RateLimitUpdatedData,
@@ -17,10 +16,6 @@ class SharedLimitClient extends BaseClient {
   ) {
     super(data, rateLimit.clientName);
     this.rateLimit = rateLimit;
-  }
-
-  public handleTokensUpdated(data: ClientTokensUpdatedData): void {
-    return;
   }
 
   public handleRateLimitUpdated(data: RateLimitUpdatedData) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -69,9 +69,6 @@ abstract class BaseClient {
     this.key = data.key;
   }
 
-  public abstract handleTokensUpdated(
-    data: ClientTypes.ClientTokensUpdatedData
-  ): void;
   public abstract handleRateLimitUpdated(
     data: ClientTypes.RateLimitUpdatedData
   ): Promise<void> | void;

--- a/src/requestHandler/startRedis.ts
+++ b/src/requestHandler/startRedis.ts
@@ -1,4 +1,5 @@
 import { ClientTokensUpdatedData, RateLimitUpdatedData } from "../client/types";
+import RequestLimitClient from "../client/clientTypes/requestLimitClient";
 import { RequestDoneData, RequestMetadata } from "../request/types";
 import updateClientRoles from "./updateClientRoles";
 import createClients from "./createClients";
@@ -129,7 +130,7 @@ function handleDestroyClient(this: RequestHandler, message: string) {
 function handleClientTokensUpdated(this: RequestHandler, message: string) {
   const data: ClientTokensUpdatedData = JSON.parse(message);
   const client = this.getClient(data.clientName);
-  client.handleTokensUpdated(data);
+  if (client instanceof RequestLimitClient) client.handleTokensUpdated(data);
 }
 
 function handleRequestAdded(this: RequestHandler, message: string) {


### PR DESCRIPTION
## Description 

This PR makes the `handleTokensUpdated` function not abstract and only defined on the `RequestLimitClient` class, since tokens have nothing to do with any of the other classes