### PR TITLE
Feature: Refresh Config Request Interceptor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vivo-technology/request-handler",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vivo-technology/request-handler",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "An external API management tool that simplifies authentication and usage of external APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/methods/authenticate.ts
+++ b/src/client/methods/authenticate.ts
@@ -96,6 +96,11 @@ async function handleRefreshMethod(
   this: Client,
   authData: AuthDataOAuth2ClientCredentials | AuthDataOAuth2GrantType
 ) {
+  if (authData.refreshConfig.requestInterceptor) {
+    authData.refreshConfig = await authData.refreshConfig.requestInterceptor(
+      authData.refreshConfig
+    );
+  }
   const config = generateConfig(authData);
   const res = await this.http(config);
   let oAuthResponse: OAuthResponse | OAuthGrantTypeResponse;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -322,6 +322,10 @@ export interface OAuthRefreshConfig {
    * Whether or not to send the clientId and clientSecret as a Base64 encoded string in Basic auth header
    */
   useBasicAuth?: boolean;
+  /** Used to update the refresh config if there is any dynamic data that changes between each refresh request*/
+  requestInterceptor?: (
+    config: OAuthRefreshConfig
+  ) => Promise<OAuthRefreshConfig> | OAuthRefreshConfig;
   /** If the provided URL does not return data in a normal OAuth standard response, use the responseInterceptor to format it into an acceptable format */
   responseInterceptor?: (
     res: AxiosResponse


### PR DESCRIPTION
## Description

This PR updates the `refreshConfig` for OAuth 2 authentication to allow for a request interceptor. This is helpful for when some part of the config is dynamic and changes between each request.